### PR TITLE
Allow migrations to be run by wrapper app

### DIFF
--- a/lib/preflight/engine.rb
+++ b/lib/preflight/engine.rb
@@ -42,5 +42,13 @@ module Preflight
     initializer "precompile zero clipboard" do |app|
       app.config.assets.precompile += %w(ZeroClipboard.swf)
     end
+
+    initializer "append_migrations" do |app|
+      unless app.root.to_s.match(root.to_s)
+        config.paths["db/migrate"].expanded.each do |expaned_path|
+          app.config.paths["db/migrate"] << expaned_path
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This will add the migrations to be run by the App that the engine lies
inside of through the normal rake db:migrate method
